### PR TITLE
FIX ISSUE-8; Allow add custom messages for rules with params

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -135,11 +135,12 @@ func (o *generatorS) validator(input interface{}) Validator {
 			if bindingTags := elementT.Tag.Get("binding"); bindingTags != "" {
 				splits := strings.Split(bindingTags, ",")
 				for j := 0; j < len(splits); j++ {
-					value := elementT.Tag.Get("_" + splits[j])
+					rule := strings.Split(splits[j], "=")
+					value := elementT.Tag.Get("_" + rule[0])
 					if value == "" {
-						value = elementT.Tag.Get(splits[j])
+						value = elementT.Tag.Get(rule[0])
 					}
-					addSpecificMessage(r, splits[j], value)
+					addSpecificMessage(r, rule[0], value)
 				}
 			}
 			rules[elementT.Name] = r


### PR DESCRIPTION
### Why:
Fix Issue 8

Closes #8 

### What's being changed:
Allow put add custom error messages for rules with params e.g 
```
type User struct {
	Name    string `json:"name" binding:"required_without=Surname"  _required_without:"$field should be filled unless surname is empty"`
	Surname    string `json:"name" binding:"required_without=Name"  _required_without:"$field should be filled unless name is empty"`
}
```
